### PR TITLE
Updated FilterGtf to handle GTF files without basic tags

### DIFF
--- a/modules/local/filter_gtf/main.nf
+++ b/modules/local/filter_gtf/main.nf
@@ -21,7 +21,7 @@ process FILTER_GTF {
     path(gtf)
 
     output:
-    path "*.gtf", emit: filtered_gtf
+    path "*.gtf", emit: post_filtering_gtf
     
     script:
     template 'FilterGtf.py'

--- a/modules/local/filter_gtf/templates/FilterGtf.py
+++ b/modules/local/filter_gtf/templates/FilterGtf.py
@@ -57,10 +57,9 @@ def filter_gff(gtf_file, outputdir):
         annotation.drop(index=df_t.index, inplace=True)
         print("Number of entries in filtered annotation.", len(annotation))
         print('Saving filtered gtf file.')
-        annotation.to_csv(f"{outputdir}/filtered.{gtf_file.split('/')[-1]}", header=None, index=None, sep='\t', quoting=csv.QUOTE_NONE)
     else:
         print('No tag \"basic\". Returning input annotation as output. Exiting.')
-        annotation.to_csv(f"{outputdir}/unfiltered.{gtf_file.split('/')[-1]}", header=None, index=None, sep='\t', quoting=csv.QUOTE_NONE)
+    annotation.to_csv(f"{outputdir}/post_filtering.{gtf_file.split('/')[-1]}", header=None, index=None, sep='\t', quoting=csv.QUOTE_NONE)
 
 # def main():
 #     (gtf_file, outputdir) = cli()

--- a/modules/local/filter_gtf/templates/FilterGtf.py
+++ b/modules/local/filter_gtf/templates/FilterGtf.py
@@ -5,7 +5,8 @@ import csv
 # import argparse
 
 # def cli():
-#     parser = argparse.ArgumentParser(description='Filter genomic annotation from GENCODE or ENSEMBL in GTF format.')
+#     parser = argparse.ArgumentParser(description='Filter genomic annotation from GENCODE or ENSEMBL in GTF format by tag \"basic\" and transcript_support_level.'\
+#     ' These flags are currently (20220223) annotated for Homo sapiens and Mus musculus organisms.')
 #     required = parser.add_argument_group('required arguments')
 #     required.add_argument('-a', '--annotation', type=str, required=True,
 #                         help='Annotation file from GENCODE or ENSEMBL in GTF format.')
@@ -36,20 +37,30 @@ def filter_gff(gtf_file, outputdir):
                                     })
     # Filter transcripts by basic tag
     print("Number of entries in input annotation:", len(annotation))
-    annotation = annotation.loc[annotation['annotations'].str.contains('tag "basic"') | (annotation['feature'] == 'gene'), :]
-    print("Number of entries after filtering for tag \"basic\":", len(annotation))
-    # Filter annotation gene-by-gene by transcript level support (TSL), to keep higher confidence transcripts where possible (TSL1 and 2)
-    df_TSL = annotation.loc[annotation['annotations'].str.contains('transcript_support_level "1|transcript_support_level "2', regex=True), :]
-    gene_ids = df_TSL["annotations"].str.split(";", n=1, expand=True)[0].unique().tolist()
-    print("Number of genes that contain TSL1 or TSL2 transcripts:", len(gene_ids))
-    # Keeping only TSL1 and TSL2 entries for genes that contain them, discardig other entries (no TSL information or TSL3-5)
-    print('Filtering out low-confidence transcripts.')
-    df_t = annotation.loc[(annotation['feature'] != 'gene') & (annotation['annotations'].str.contains('|'.join(gene_ids))) , :]
-    df_t = df_t.loc[~df_t['annotations'].str.contains('transcript_support_level "1"|transcript_support_level "2"', regex=True)]
-    annotation.drop(index=df_t.index, inplace=True)
-    print("Number of entries in filtered annotation.", len(annotation))
-    print('Saving filtered gtf file.')
-    annotation.to_csv(f"{outputdir}/filtered.{gtf_file.split('/')[-1]}", header=None, index=None, sep='\t', quoting=csv.QUOTE_NONE)
+    # Check if annotation contains tag "basic"
+    print("Checking for basic flag...")
+    basic = annotation['annotations'].str.contains('basic', regex=True)
+    if basic.any():
+        print("Basic flag available.")
+        nbasic = basic.value_counts()[True]
+        print(f"{nbasic} entries flagged as basic.")
+        annotation = annotation.loc[annotation['annotations'].str.contains('tag "basic"') | (annotation['feature'] == 'gene'), :]
+        print("Number of entries after filtering for tag \"basic\":", len(annotation))
+        # Filter annotation gene-by-gene by transcript level support (TSL), to keep higher confidence transcripts where possible (TSL1 and 2)
+        df_TSL = annotation.loc[annotation['annotations'].str.contains('transcript_support_level "1|transcript_support_level "2', regex=True), :]
+        gene_ids = df_TSL["annotations"].str.split(";", n=1, expand=True)[0].unique().tolist()
+        print("Number of genes that contain TSL1 or TSL2 transcripts:", len(gene_ids))
+        # Keeping only TSL1 and TSL2 entries for genes that contain them, discardig other entries (no TSL information or TSL3-5)
+        print('Filtering out low-confidence transcripts.')
+        df_t = annotation.loc[(annotation['feature'] != 'gene') & (annotation['annotations'].str.contains('|'.join(gene_ids))) , :]
+        df_t = df_t.loc[~df_t['annotations'].str.contains('transcript_support_level "1"|transcript_support_level "2"', regex=True)]
+        annotation.drop(index=df_t.index, inplace=True)
+        print("Number of entries in filtered annotation.", len(annotation))
+        print('Saving filtered gtf file.')
+        annotation.to_csv(f"{outputdir}/filtered.{gtf_file.split('/')[-1]}", header=None, index=None, sep='\t', quoting=csv.QUOTE_NONE)
+    else:
+        print('No tag \"basic\". Returning input annotation as output. Exiting.')
+        annotation.to_csv(f"{outputdir}/unfiltered.{gtf_file.split('/')[-1]}", header=None, index=None, sep='\t', quoting=csv.QUOTE_NONE)
 
 # def main():
 #     (gtf_file, outputdir) = cli()

--- a/workflows/preparegenome.nf
+++ b/workflows/preparegenome.nf
@@ -55,14 +55,14 @@ workflow {
 
     // Create genome segmentation file using iCount
     ICOUNT_SEGMENT (
-        FILTER_GTF.out.filtered_gtf,
+        FILTER_GTF.out.post_filtering_gtf,
         ch_fai
     )
 
 
     RESOLVE_UNANNOTATED(
         ICOUNT_SEGMENT.out.regions, // segment
-        FILTER_GTF.out.filtered_gtf, // gtf
+        FILTER_GTF.out.post_filtering_gtf, // gtf
         ch_fai, // fai
     )
 


### PR DESCRIPTION
Implements Klara's updates to the FilterGtf script to allow it to work with GTF files without basic tags.

Something which might break something is that the script outputs a file called `filtered.*.gtf` or `unfiltered.*.gtf` depending on whether it does any filtering. Regardless, the Nextflow module output is still called `filtered_gtf` which is a bit confusing / annoying, but I didn't change it as it would require changes in the workflows. I can make those changes if you'd prefer though?