### PR TITLE
Fix genome match

### DIFF
--- a/subworkflows/primaryclipanalysis.config
+++ b/subworkflows/primaryclipanalysis.config
@@ -16,6 +16,6 @@ process {
     }
 
     withName: "UMITOOLS_DEDUP" {
-        ext.args = "--umi-separator='${umi_separator}:'"
+        ext.args = "--umi-separator='${umi_separator}:' --method unique"
     }
 }

--- a/subworkflows/primaryclipanalysis.config
+++ b/subworkflows/primaryclipanalysis.config
@@ -18,4 +18,8 @@ process {
     withName: "UMITOOLS_DEDUP" {
         ext.args = "--umi-separator='${umi_separator}:' --method unique"
     }
+
+    withName: "TOME_UMITOOLS_DEDUP" {
+        ext.args = "--umi-separator='${umi_separator}:' --method unique"
+    }
 }

--- a/subworkflows/primaryclipanalysis.nf
+++ b/subworkflows/primaryclipanalysis.nf
@@ -154,9 +154,9 @@ workflow PRIMARY_CLIP_ANALYSIS {
     UMITOOLS_SAMTOOLS_INDEX ( UMITOOLS_DEDUP.out.bam )
     reads.map{triplet -> [
         triplet[0], file(triplet[2] + "/SAMTOOLS_FAIDX/*.fa.fai")
-    ]}.set{ ch_genome_fa }
+    ]}.set{ ch_genome_fai }
     ch_xl_input = UMITOOLS_DEDUP.out.bam.combine(UMITOOLS_SAMTOOLS_INDEX.out.bai, by: 0)
-    ch_xl_input.join( ch_genome_fa ).set{ ch_with_index }
+    ch_xl_input.join( ch_genome_fai ).set{ ch_with_index }
     ch_with_index.multiMap { tuple ->
         bam: [tuple[0], tuple[1], tuple[2]]
         transcript: tuple[3]
@@ -166,7 +166,7 @@ workflow PRIMARY_CLIP_ANALYSIS {
     CROSSLINKS_NORMCOVERAGE ( GET_CROSSLINKS.out.crosslinkBed )
 
     // CLIPPY Peak Calling
-    GET_CROSSLINKS.out.crosslinkBed.join( ch_gtf ).join( ch_genome_fa ).set{ ch_crosslinks }
+    GET_CROSSLINKS.out.crosslinkBed.join( ch_gtf ).join( ch_genome_fai ).set{ ch_crosslinks }
     ch_crosslinks.multiMap { tuple ->
         crosslinks: [tuple[0], tuple[1]]
         gtf: tuple[2]
@@ -218,7 +218,7 @@ workflow PRIMARY_CLIP_ANALYSIS {
     CLIPPY.out.peaks
     .join(GET_CROSSLINKS.out.crosslinkBed)
     .join(ch_fasta)
-    .join(ch_genome_fa)
+    .join(ch_genome_fai)
     .join(ch_regions_genic_other)
     .set{ ch_peka_joins }
     ch_peka_joins.multiMap { tuple ->

--- a/subworkflows/primaryclipanalysis.nf
+++ b/subworkflows/primaryclipanalysis.nf
@@ -40,7 +40,7 @@ workflow {
         id: params.fastq.split("/")[-1].replace(".gz", "").replace(".fastq", "").replace("ultraplex_demux_", ""),
         species: species,
         single_end: true
-    ], file(params.fastq), genomeParamName]
+    ], file(params.fastq), params[genomeParamName]]
 
     // Now just pass that along
     PRIMARY_CLIP_ANALYSIS (

--- a/subworkflows/primaryclipanalysis.nf
+++ b/subworkflows/primaryclipanalysis.nf
@@ -170,9 +170,9 @@ workflow PRIMARY_CLIP_ANALYSIS {
     ch_crosslinks.multiMap { tuple ->
         crosslinks: [tuple[0], tuple[1]]
         gtf: tuple[2]
-        fa: tuple[3]
+        fai: tuple[3]
     }.set { ch_clippy_input }
-    CLIPPY ( ch_clippy_input.crosslinks,  ch_clippy_input.gtf,  ch_clippy_input.fa )
+    CLIPPY ( ch_clippy_input.crosslinks,  ch_clippy_input.gtf,  ch_clippy_input.fai )
 
     // Paraclu Peak Calling
     PARACLU_PARACLU ( GET_CROSSLINKS.out.crosslinkBed )

--- a/workflows/demuxandanalyse.json
+++ b/workflows/demuxandanalyse.json
@@ -22,7 +22,7 @@
                     "type": "string",
                     "format": "file-path",
                     "mimetype": "text/plain",
-                    "pattern": "fq\\.gz|fastq\\.gz",
+                    "pattern": "fq\\.gz|fastq\\.gz|fq",
                     "imapsType": "multiplexed",
                     "required": true,
                     "description": "A multiplexed reads file containing reads from multiple experiments, distinguishable by barcode sequence."

--- a/workflows/demuxandanalyse.nf
+++ b/workflows/demuxandanalyse.nf
@@ -16,21 +16,21 @@ workflow {
     // Run Primary CLIP Analysis
     DEMULTIPLEX.out
     .filter{pair -> pair[0].pipeline == "Primary CLIP Analysis"}
+    .map{pair -> [pair[0], pair[1], params[pair[0].species + "_genome"]]}
     .set{ ch_primary_clip_analysis_reads }
 
     PRIMARY_CLIP_ANALYSIS (
-        ch_primary_clip_analysis_reads, // [meta, reads] pairs
-        ch_primary_clip_analysis_reads.map{pair -> params[pair[0].species + "_genome"]}
+        ch_primary_clip_analysis_reads, // [meta, reads, genome_name] triplets
     )
 
     // Run Non-Coding RNA Analysis
     DEMULTIPLEX.out
     .filter{pair -> pair[0].pipeline == "Non-Coding RNA Analysis"}
+    .map{pair -> [pair[0], pair[1], file(params[pair[0].species + "_genome"])]}
     .set{ ch_ncrna_reads }
 
     NCRNA_ANALYSIS (
-        ch_ncrna_reads, // [meta, reads] pairs
-        ch_ncrna_reads.map{pair -> params[pair[0].species + "_genome"]}
+        ch_ncrna_reads, // [meta, reads, genome_name] triplets
     )
 
 }


### PR DESCRIPTION
This is the proposed fix for the genome switching issue we had. There are a few checks/changes that might be needed before merging:

- Marc could you check the changes I made to primaryclipanalysis.nf? I basically took the pattern you used to get TRIMGALORE to work and applied it everywhere a channel had two inputs that needed to be kept in line with each other.
- I’ve added a `--method unique` to DEDUP processes - I gather from Charlotte that this needs to be both generated from the file contents as well as being overridable, so this will need to be modified.
- I also gather there are some CLIPPY changes to be made?